### PR TITLE
Add logout button (#8) and edit profile page (#6) with frontend fixes

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,18 +1,19 @@
 import { useEffect, useState } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import logo from "../assets/rallypoint-logo.png";
-import { FiMenu, FiX } from "react-icons/fi";
+import { FiMenu, FiX, FiLogOut } from "react-icons/fi";
 
 const Navbar = () => {
     const location = useLocation();
+    const navigate = useNavigate();
     const [loggedIn, setLoggedIn] = useState(false);
     const [menuOpen, setMenuOpen] = useState(false);
 
-    // Simulate logged-in state for demonstration purposes
+    // Check auth state on mount and route changes
     useEffect(() => {
         const isAuthenticated = localStorage.getItem("loggedIn") === "true";
         setLoggedIn(isAuthenticated);
-    }, []);
+    }, [location.pathname]);
 
     const isActive = (path) => {
         return location.pathname === path
@@ -24,6 +25,13 @@ const Navbar = () => {
     useEffect(() => {
         setMenuOpen(false);
     }, [location.pathname]);
+
+    const handleLogout = () => {
+        localStorage.removeItem("loggedIn");
+        setLoggedIn(false);
+        setMenuOpen(false);
+        navigate("/");
+    };
 
     return (
         <nav className="h-[11vh] w-full bg-[#f8f8f8] text-black p-4 flex justify-around items-center shadow-md relative top-0 z-50">
@@ -47,6 +55,7 @@ const Navbar = () => {
                         {menuOpen ? <FiX /> : <FiMenu />}
                     </button>
                 </div>
+                {/* Desktop nav */}
                 <div className="hidden md:flex space-x-8 font-semibold items-center">
                     <Link to="/" className={isActive("/")}>
                         Home
@@ -60,14 +69,34 @@ const Navbar = () => {
                     <Link to="/rankings" className={isActive("/rankings")}>
                         Rankings
                     </Link>
-                    <Link
-                        className="hover:cursor-pointer px-4 py-2 text-[#f8f8f8] bg-blue-900 hover:bg-blue-600 rounded-md transition-colors duration-300 ml-2"
-                        to={loggedIn ? "/profile" : "/login"}
-                    >
-                        {loggedIn ? "Account" : "Login"}
-                    </Link>
+                    {loggedIn ? (
+                        <div className="flex items-center space-x-3 ml-2">
+                            <Link
+                                className="hover:cursor-pointer px-4 py-2 text-[#f8f8f8] bg-blue-900 hover:bg-blue-600 rounded-md transition-colors duration-300"
+                                to="/profile"
+                            >
+                                Account
+                            </Link>
+                            <button
+                                onClick={handleLogout}
+                                className="flex items-center gap-1.5 px-3 py-2 text-red-600 hover:bg-red-50 rounded-md transition-colors duration-300 hover:cursor-pointer"
+                                title="Log out"
+                            >
+                                <FiLogOut className="text-lg" />
+                                <span className="text-sm font-medium">Logout</span>
+                            </button>
+                        </div>
+                    ) : (
+                        <Link
+                            className="hover:cursor-pointer px-4 py-2 text-[#f8f8f8] bg-blue-900 hover:bg-blue-600 rounded-md transition-colors duration-300 ml-2"
+                            to="/login"
+                        >
+                            Login
+                        </Link>
+                    )}
                 </div>
             </div>
+            {/* Mobile side menu */}
             <div
                 className={`md:hidden fixed top-0 right-0 w-3/4 max-w-xs h-full bg-[#f8f8f8] shadow-lg z-50 transform transition-transform duration-300 ${
                     menuOpen ? "translate-x-0" : "translate-x-full"
@@ -105,13 +134,32 @@ const Navbar = () => {
                     >
                         Rankings
                     </Link>
-                    <Link
-                        className="hover:cursor-pointer px-4 py-2 text-[#f8f8f8] bg-blue-900 hover:bg-blue-600 rounded-md transition-colors duration-300 mt-2"
-                        to={loggedIn ? "/profile" : "/login"}
-                        onClick={() => setMenuOpen(false)}
-                    >
-                        {loggedIn ? "Account" : "Login"}
-                    </Link>
+                    {loggedIn ? (
+                        <>
+                            <Link
+                                className="hover:cursor-pointer px-4 py-2 text-[#f8f8f8] bg-blue-900 hover:bg-blue-600 rounded-md transition-colors duration-300 text-center mt-2"
+                                to="/profile"
+                                onClick={() => setMenuOpen(false)}
+                            >
+                                Account
+                            </Link>
+                            <button
+                                onClick={handleLogout}
+                                className="flex items-center justify-center gap-2 px-4 py-2 text-red-600 border border-red-200 hover:bg-red-50 rounded-md transition-colors duration-300 hover:cursor-pointer"
+                            >
+                                <FiLogOut />
+                                <span>Logout</span>
+                            </button>
+                        </>
+                    ) : (
+                        <Link
+                            className="hover:cursor-pointer px-4 py-2 text-[#f8f8f8] bg-blue-900 hover:bg-blue-600 rounded-md transition-colors duration-300 mt-2"
+                            to="/login"
+                            onClick={() => setMenuOpen(false)}
+                        >
+                            Login
+                        </Link>
+                    )}
                 </div>
             </div>
         </nav>

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,1 +1,3 @@
-export const API_BASE_URL = 'http://localhost:5000';
+// In development, Vite proxy forwards /api/* to localhost:5000
+// so we use an empty base URL (same-origin requests).
+export const API_BASE_URL = '';

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -36,10 +36,4 @@ button:focus-visible {
         color: #213547;
         background-color: #ffffff;
     }
-    a:hover {
-        color: #747bff;
-    }
-    button {
-        background-color: #f9f9f9;
-    }
 }

--- a/frontend/src/pages/ForgotPage.jsx
+++ b/frontend/src/pages/ForgotPage.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import logo from "../assets/rallypoint-logo.png";
 
-const API_BASE_URL = "http://localhost:5000";
+import { API_BASE_URL } from "../config";
 
 function ForgotPage() {
     const [email, setEmail] = useState("");

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import logo from "../assets/rallypoint-logo.png";
 
-const API_BASE_URL = "http://localhost:5000";
+import { API_BASE_URL } from "../config";
 
 const LoginPage = () => {
     const [form, setForm] = useState({ email: "", password: "" });
@@ -29,6 +29,17 @@ const LoginPage = () => {
                         "Login failed. Please check your credentials."
                 );
             }
+            const data = await response.json();
+            // Store auth state
+            localStorage.setItem("loggedIn", "true");
+            localStorage.setItem("token", data.token);
+            // Decode user ID from JWT payload
+            try {
+                const payload = JSON.parse(atob(data.token.split(".")[1]));
+                localStorage.setItem("userId", payload.id);
+            } catch {
+                // token decode failed, continue anyway
+            }
             navigate("/", { replace: true });
         } catch (err) {
             setError(err.message);
@@ -52,7 +63,7 @@ const LoginPage = () => {
                 <h2 className="text-[#fff] text-3xl h-[10%] font-bold">
                     Login
                 </h2>
-                {error && <div>{error}</div>}
+                {error && <div className="w-full max-w-md mb-3 p-3 bg-red-500/20 border border-red-400 text-red-200 rounded-md text-sm text-center">{error}</div>}
                 <form
                     className="flex flex-col h-[30%] justify-around w-full max-w-md"
                     onSubmit={handleSubmit}

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,0 +1,363 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { API_BASE_URL } from "../config";
+
+const ProfilePage = () => {
+    const navigate = useNavigate();
+    const [isEditing, setIsEditing] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSaving, setIsSaving] = useState(false);
+    const [error, setError] = useState(null);
+    const [success, setSuccess] = useState(null);
+
+    const [profile, setProfile] = useState({
+        first_name: "",
+        last_name: "",
+        username: "",
+        email: "",
+        phone_number: "",
+        gender: "",
+        date_of_birth: "",
+        city: "",
+        state_province: "",
+        zip_code: "",
+        country: "",
+    });
+
+    const [editForm, setEditForm] = useState({ ...profile });
+
+    useEffect(() => {
+        const fetchProfile = async () => {
+            try {
+                const userId = localStorage.getItem("userId");
+                if (!userId) {
+                    navigate("/login");
+                    return;
+                }
+
+                const response = await fetch(
+                    `${API_BASE_URL}/api/users/${userId}`,
+                    {
+                        credentials: "include",
+                    }
+                );
+
+                if (!response.ok) {
+                    throw new Error("Failed to load profile");
+                }
+
+                const data = await response.json();
+                const profileData = {
+                    first_name: data.first_name || "",
+                    last_name: data.last_name || "",
+                    username: data.username || "",
+                    email: data.email || "",
+                    phone_number: data.phone_number || "",
+                    gender: data.gender || "",
+                    date_of_birth: data.date_of_birth
+                        ? data.date_of_birth.split("T")[0]
+                        : "",
+                    city: data.city || "",
+                    state_province: data.state_province || "",
+                    zip_code: data.zip_code || "",
+                    country: data.country || "",
+                };
+                setProfile(profileData);
+                setEditForm(profileData);
+            } catch (err) {
+                setError(err.message);
+                // Use placeholder data when backend is unavailable
+                const placeholder = {
+                    first_name: "Demo",
+                    last_name: "User",
+                    username: "demo.user",
+                    email: "demo@rallypoint.com",
+                    phone_number: "555-0100",
+                    gender: "male",
+                    date_of_birth: "2000-01-15",
+                    city: "Columbus",
+                    state_province: "OH",
+                    zip_code: "43201",
+                    country: "USA",
+                };
+                setProfile(placeholder);
+                setEditForm(placeholder);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchProfile();
+    }, [navigate]);
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setEditForm((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const handleCancel = () => {
+        setEditForm({ ...profile });
+        setIsEditing(false);
+        setError(null);
+        setSuccess(null);
+    };
+
+    const handleSave = async (e) => {
+        e.preventDefault();
+        setIsSaving(true);
+        setError(null);
+        setSuccess(null);
+
+        try {
+            const userId = localStorage.getItem("userId");
+            const response = await fetch(
+                `${API_BASE_URL}/api/users/${userId}`,
+                {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    credentials: "include",
+                    body: JSON.stringify(editForm),
+                }
+            );
+
+            if (!response.ok) {
+                const data = await response.json();
+                throw new Error(data.message || "Failed to update profile");
+            }
+
+            const updated = await response.json();
+            const profileData = {
+                first_name: updated.first_name || editForm.first_name,
+                last_name: updated.last_name || editForm.last_name,
+                username: updated.username || editForm.username,
+                email: updated.email || editForm.email,
+                phone_number: updated.phone_number || editForm.phone_number,
+                gender: updated.gender || editForm.gender,
+                date_of_birth: updated.date_of_birth
+                    ? updated.date_of_birth.split("T")[0]
+                    : editForm.date_of_birth,
+                city: updated.city || editForm.city,
+                state_province:
+                    updated.state_province || editForm.state_province,
+                zip_code: updated.zip_code || editForm.zip_code,
+                country: updated.country || editForm.country,
+            };
+            setProfile(profileData);
+            setEditForm(profileData);
+            setIsEditing(false);
+            setSuccess("Profile updated successfully!");
+        } catch (err) {
+            setError(err.message);
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    if (isLoading) {
+        return (
+            <div className="min-h-screen w-screen bg-[#f8f8f8] flex items-center justify-center">
+                <p className="text-gray-500 text-lg">Loading profile...</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-screen w-screen bg-[#f8f8f8] text-gray-800">
+            <div className="max-w-3xl mx-auto px-6 py-10">
+                <div className="flex justify-between items-center mb-8">
+                    <h1 className="text-3xl font-bold">My Profile</h1>
+                    {!isEditing && (
+                        <button
+                            onClick={() => setIsEditing(true)}
+                            className="px-5 py-2 bg-blue-900 text-white rounded-md hover:bg-blue-700 transition-colors duration-300 font-medium hover:cursor-pointer"
+                        >
+                            Edit Profile
+                        </button>
+                    )}
+                </div>
+
+                {success && (
+                    <div className="mb-4 p-3 bg-green-50 text-green-700 rounded-md text-sm">
+                        {success}
+                    </div>
+                )}
+                {error && (
+                    <div className="mb-4 p-3 bg-red-50 text-red-600 rounded-md text-sm">
+                        {error}
+                    </div>
+                )}
+
+                <form onSubmit={handleSave}>
+                    <div className="bg-white rounded-lg shadow-sm p-6 space-y-6">
+                        {/* Name */}
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <ProfileField
+                                label="First Name"
+                                name="first_name"
+                                value={editForm.first_name}
+                                editing={isEditing}
+                                onChange={handleChange}
+                            />
+                            <ProfileField
+                                label="Last Name"
+                                name="last_name"
+                                value={editForm.last_name}
+                                editing={isEditing}
+                                onChange={handleChange}
+                            />
+                        </div>
+
+                        {/* Username & Email */}
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <ProfileField
+                                label="Username"
+                                name="username"
+                                value={editForm.username}
+                                editing={isEditing}
+                                onChange={handleChange}
+                            />
+                            <ProfileField
+                                label="Email"
+                                name="email"
+                                value={editForm.email}
+                                editing={false}
+                                type="email"
+                            />
+                        </div>
+
+                        {/* Phone & Gender */}
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <ProfileField
+                                label="Phone"
+                                name="phone_number"
+                                value={editForm.phone_number}
+                                editing={isEditing}
+                                onChange={handleChange}
+                                type="tel"
+                            />
+                            <div>
+                                <label className="block text-sm font-medium text-gray-500 mb-1">
+                                    Gender
+                                </label>
+                                {isEditing ? (
+                                    <select
+                                        name="gender"
+                                        value={editForm.gender}
+                                        onChange={handleChange}
+                                        className="w-full p-3 rounded-md bg-gray-50 text-black border border-gray-300 focus:ring-2 focus:ring-blue-900 focus:outline-none"
+                                    >
+                                        <option value="">Select gender</option>
+                                        <option value="male">Male</option>
+                                        <option value="female">Female</option>
+                                        <option value="other">Other</option>
+                                    </select>
+                                ) : (
+                                    <p className="text-gray-800 p-3 bg-gray-50 rounded-md capitalize">
+                                        {editForm.gender || "—"}
+                                    </p>
+                                )}
+                            </div>
+                        </div>
+
+                        {/* DOB */}
+                        <ProfileField
+                            label="Date of Birth"
+                            name="date_of_birth"
+                            value={editForm.date_of_birth}
+                            editing={isEditing}
+                            onChange={handleChange}
+                            type="date"
+                        />
+
+                        {/* Location */}
+                        <h3 className="text-lg font-semibold text-gray-700 pt-2 border-t">
+                            Location
+                        </h3>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <ProfileField
+                                label="City"
+                                name="city"
+                                value={editForm.city}
+                                editing={isEditing}
+                                onChange={handleChange}
+                            />
+                            <ProfileField
+                                label="State / Province"
+                                name="state_province"
+                                value={editForm.state_province}
+                                editing={isEditing}
+                                onChange={handleChange}
+                            />
+                        </div>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <ProfileField
+                                label="Zip Code"
+                                name="zip_code"
+                                value={editForm.zip_code}
+                                editing={isEditing}
+                                onChange={handleChange}
+                            />
+                            <ProfileField
+                                label="Country"
+                                name="country"
+                                value={editForm.country}
+                                editing={isEditing}
+                                onChange={handleChange}
+                            />
+                        </div>
+
+                        {/* Action buttons */}
+                        {isEditing && (
+                            <div className="flex gap-3 pt-4 border-t">
+                                <button
+                                    type="submit"
+                                    disabled={isSaving}
+                                    className="px-6 py-2 bg-blue-900 text-white rounded-md hover:bg-blue-700 transition-colors duration-300 font-medium disabled:opacity-50 hover:cursor-pointer"
+                                >
+                                    {isSaving ? "Saving..." : "Save Changes"}
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={handleCancel}
+                                    className="px-6 py-2 border border-gray-300 text-gray-600 rounded-md hover:bg-gray-50 transition-colors duration-300 font-medium hover:cursor-pointer"
+                                >
+                                    Cancel
+                                </button>
+                            </div>
+                        )}
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+};
+
+const ProfileField = ({
+    label,
+    name,
+    value,
+    editing,
+    onChange,
+    type = "text",
+}) => (
+    <div>
+        <label className="block text-sm font-medium text-gray-500 mb-1">
+            {label}
+        </label>
+        {editing ? (
+            <input
+                type={type}
+                name={name}
+                value={value}
+                onChange={onChange}
+                className="w-full p-3 rounded-md bg-gray-50 text-black border border-gray-300 focus:ring-2 focus:ring-blue-900 focus:outline-none"
+            />
+        ) : (
+            <p className="text-gray-800 p-3 bg-gray-50 rounded-md">
+                {value || "—"}
+            </p>
+        )}
+    </div>
+);
+
+export default ProfilePage;

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -35,10 +35,13 @@ const ProfilePage = () => {
                     return;
                 }
 
+                const token = localStorage.getItem("token");
                 const response = await fetch(
                     `${API_BASE_URL}/api/users/${userId}`,
                     {
-                        credentials: "include",
+                        headers: {
+                            Authorization: `Bearer ${token}`,
+                        },
                     }
                 );
 
@@ -110,12 +113,15 @@ const ProfilePage = () => {
 
         try {
             const userId = localStorage.getItem("userId");
+            const token = localStorage.getItem("token");
             const response = await fetch(
                 `${API_BASE_URL}/api/users/${userId}`,
                 {
                     method: "PUT",
-                    headers: { "Content-Type": "application/json" },
-                    credentials: "include",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${token}`,
+                    },
                     body: JSON.stringify(editForm),
                 }
             );

--- a/frontend/src/pages/RegistrationPage.jsx
+++ b/frontend/src/pages/RegistrationPage.jsx
@@ -3,7 +3,7 @@ import { useNavigate, Link } from "react-router-dom";
 import logo from "../assets/rallypoint-logo.png";
 
 const GEOAPIFY_API_KEY = "3cfdf04a71db4f31a3bf17a9d206d45e";
-const API_BASE_URL = "http://localhost:5000";
+import { API_BASE_URL } from "../config";
 
 const RegistrationPage = () => {
     const [formData, setFormData] = useState({

--- a/frontend/src/pages/ResetPasswordPage.jsx
+++ b/frontend/src/pages/ResetPasswordPage.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { Link, useParams, useNavigate } from "react-router-dom";
 import logo from "../assets/rallypoint-logo.png";
 
-const API_BASE_URL = "http://localhost:5000";
+import { API_BASE_URL } from "../config";
 
 function ResetPasswordPage() {
     const [password, setPassword] = useState("");

--- a/frontend/src/routes/AppRoutes.jsx
+++ b/frontend/src/routes/AppRoutes.jsx
@@ -11,6 +11,7 @@ import CreateTournamentRegistration from "../pages/CreateTournamentRegistration"
 // import RankingsPage from '../pages/RankingsPage';
 import NotFoundPage from "../pages/NotFoundPage";
 import AboutPage from "../pages/AboutPage";
+import ProfilePage from "../pages/ProfilePage";
 import Layout from "../components/Outlet";
 import ForgotPage from "../pages/ForgotPage";
 import ResetPasswordPage from "../pages/ResetPasswordPage";
@@ -25,6 +26,7 @@ const AppRoutes = () => {
                 <Route path="/events/create/format" element={<CreateTournamentFormat />} />
                 <Route path="/events/create/registration" element={<CreateTournamentRegistration />} />
                 <Route path="/about" element={<AboutPage />} />
+                <Route path="/profile" element={<ProfilePage />} />
             </Route>
 
             <Route path="/login" element={<LoginPage />} />

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,4 +8,12 @@ export default defineConfig({
     react(),
     tailwindcss()
   ],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary

This PR addresses two backlog items from **Milestone 1: User Registration and Authentication**, plus several supporting fixes discovered during development and testing.

### Backlog Items

- **Issue #8 — Add ability to log out (should have)**
  Adds a visible Logout button (with `FiLogOut` icon) to both desktop and mobile Navbar. When clicked, clears `localStorage` auth state and redirects the user to the home page. The button only appears when the user is logged in; otherwise the Navbar shows "Login."

- **Issue #6 — Add ability to edit profile info (must have)**
  New `ProfilePage` component at `/profile` with a view/edit mode toggle. Displays all user fields (name, username, email, phone, gender, DOB, city, state, zip, country) fetched from `GET /api/users/:id`. Users can click "Edit Profile" to modify fields inline, then "Save Changes" to persist via `PUT /api/users/:id`. Email is read-only. Graceful fallback to demo data when backend is unavailable.

### Additional Fixes

These issues were discovered while testing the two features end-to-end:

- **Vite dev proxy** — Added `/api` proxy in `vite.config.js` to route API calls through the Vite dev server, resolving browser CORS / Private Network Access blocks that caused "Failed to fetch" errors.
- **Centralized API base URL** — Replaced hardcoded `http://localhost:5000` in `LoginPage`, `RegistrationPage`, `ForgotPage`, and `ResetPasswordPage` with a shared `config.ts` import.
- **Login auth storage** — `LoginPage` now decodes the JWT response and stores `token`, `userId`, and `loggedIn` flag in `localStorage`, enabling the Navbar and Profile page to function.
- **Profile auth headers** — Profile fetch/update calls now include `Authorization: Bearer <token>` header, which the backend's `verifyToken` middleware requires.
- **Login error visibility** — Styled the error message on `LoginPage` so it's visible against the dark blue background.
- **Button/link color fix** — Removed Vite scaffold CSS in `index.css` (`button { background-color: #f9f9f9 }` and `a:hover { color: #747bff }`) that was overriding all Tailwind utility classes on buttons and links site-wide.

### Files Changed

| File | Change |
|---|---|
| `components/Navbar.jsx` | Logout button, auth-aware rendering, `useNavigate` |
| `pages/ProfilePage.jsx` | **New** — full profile view/edit page |
| `routes/AppRoutes.jsx` | Added `/profile` route |
| `pages/LoginPage.jsx` | JWT storage, config import, error styling |
| `pages/RegistrationPage.jsx` | Config import |
| `pages/ForgotPage.jsx` | Config import |
| `pages/ResetPasswordPage.jsx` | Config import |
| `vite.config.js` | Dev proxy for `/api` |
| `config.ts` | Changed to empty base URL for proxy |
| `index.css` | Removed conflicting button/link CSS |

## Test Plan

- [ ] Login with `basicuser@example.com` / `basicpass123` — should redirect to home, Navbar shows "Account" + "Logout"
- [ ] Navigate to `/profile` — real user data loads from backend
- [ ] Click "Edit Profile", modify a field, click "Save Changes" — profile updates persist
- [ ] Click "Logout" — clears session, Navbar reverts to "Login"
- [ ] Verify all buttons (Navbar, Hero, EventCards, Login, Register) display correct Tailwind colors
- [ ] Test on mobile viewport — logout button appears in mobile slide-out menu
