### PR TITLE
fix: resolve merge conflicts from edit-profile PR merge

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -9,39 +9,29 @@ const Navbar = () => {
   const [loggedIn, setLoggedIn] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
 
-  // Simulate logged-in state for demonstration purposes
-  useEffect(() => {
-    const hasToken = Boolean(localStorage.getItem("authToken"));
-    setLoggedIn(hasToken);
-  }, [location.pathname]);
+    // Check auth state on route change
+    useEffect(() => {
+        const hasToken = Boolean(localStorage.getItem("authToken"));
+        setLoggedIn(hasToken);
+        setMenuOpen(false);
+    }, [location.pathname]);
 
-  const handleLogout = () => {
-    localStorage.removeItem("authToken");
-    // Clear any in-progress wizard data too
-    localStorage.removeItem("tournamentBasicInfo");
-    localStorage.removeItem("tournamentFormat");
-    localStorage.removeItem("tournamentRegistration");
-    setLoggedIn(false);
-    setMenuOpen(false);
-    navigate("/", { replace: true });
-  };
+    const handleLogout = () => {
+        localStorage.removeItem("authToken");
+        localStorage.removeItem("loggedIn");
+        localStorage.removeItem("userId");
+        localStorage.removeItem("tournamentBasicInfo");
+        localStorage.removeItem("tournamentFormat");
+        localStorage.removeItem("tournamentRegistration");
+        setLoggedIn(false);
+        setMenuOpen(false);
+        navigate("/", { replace: true });
+    };
 
     const isActive = (path) => {
         return location.pathname === path
             ? "text-black hover:text-blue-900"
             : "text-blue-900";
-    };
-
-    // Close menu on route change
-    useEffect(() => {
-        setMenuOpen(false);
-    }, [location.pathname]);
-
-    const handleLogout = () => {
-        localStorage.removeItem("loggedIn");
-        setLoggedIn(false);
-        setMenuOpen(false);
-        navigate("/");
     };
 
     return (

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -32,7 +32,7 @@ const LoginPage = () => {
             const data = await response.json();
             // Store auth state
             localStorage.setItem("loggedIn", "true");
-            localStorage.setItem("token", data.token);
+            localStorage.setItem("authToken", data.token);
             // Decode user ID from JWT payload
             try {
                 const payload = JSON.parse(atob(data.token.split(".")[1]));

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -35,7 +35,7 @@ const ProfilePage = () => {
                     return;
                 }
 
-                const token = localStorage.getItem("token");
+                const token = localStorage.getItem("authToken");
                 const response = await fetch(
                     `${API_BASE_URL}/api/users/${userId}`,
                     {
@@ -113,7 +113,7 @@ const ProfilePage = () => {
 
         try {
             const userId = localStorage.getItem("userId");
-            const token = localStorage.getItem("token");
+            const token = localStorage.getItem("authToken");
             const response = await fetch(
                 `${API_BASE_URL}/api/users/${userId}`,
                 {


### PR DESCRIPTION
## Summary

- **Navbar.jsx**: Removed duplicate `handleLogout` and `useEffect` declarations that were introduced when PR #56 (edit-profile) was merged alongside PRs #53/#54 (tournament-create-auth, logout-button). Unified into a single `useEffect` that checks auth state and closes the mobile menu on route change, and a single `handleLogout` that clears all auth-related localStorage keys (`authToken`, `loggedIn`, `userId`, and wizard data).

- **LoginPage.jsx**: Changed `localStorage.setItem("token", ...)` to `localStorage.setItem("authToken", ...)` so the stored JWT key matches what `CreateTournament*.tsx`, `TournamentsPage.tsx`, and `Navbar.jsx` all read.

- **ProfilePage.jsx**: Changed both `localStorage.getItem("token")` calls to `localStorage.getItem("authToken")` for consistency.

## Root Cause
PR #56 was based on a branch that used `token` and `loggedIn` as localStorage keys, while PRs #53/#54 (merged into main first) introduced `authToken`. The GitHub merge combined both code paths, creating duplicate declarations (build error) and key mismatches (auth not working across pages).

## Test Plan
- [x] `npm run build` passes cleanly (was failing with duplicate symbol error before)
- [x] Login via `/api/auth/login` returns JWT and stores as `authToken`
- [x] Profile page reads `authToken` and fetches user data successfully
- [x] Logout clears all auth keys
- [x] CreateTournament pages correctly read `authToken`
