### PR TITLE
fix: address review comments from merged PR #61

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -3,8 +3,5 @@
 // so we use an empty base URL (same-origin requests).
 export const API_BASE_URL = '';
 
-// Existing project default key is kept for local developer convenience.
-// Override with VITE_GEOAPIFY_API_KEY in .env for your own key.
 export const GEOAPIFY_API_KEY =
-  import.meta.env.VITE_GEOAPIFY_API_KEY?.trim() ||
-  "3cfdf04a71db4f31a3bf17a9d206d45e";
+  import.meta.env.VITE_GEOAPIFY_API_KEY?.trim() || "";

--- a/frontend/src/pages/CreateTournamentBasicInfo.tsx
+++ b/frontend/src/pages/CreateTournamentBasicInfo.tsx
@@ -68,6 +68,7 @@ const CreateTournamentBasicInfo = () => {
     const [addressLoading, setAddressLoading] = useState(false);
     const navigate = useNavigate();
     const todayIso = new Date().toISOString().slice(0, 10);
+    const isAddressAutocompleteEnabled = Boolean(GEOAPIFY_API_KEY);
 
     useEffect(() => {
         const token = localStorage.getItem("authToken");
@@ -82,12 +83,13 @@ const CreateTournamentBasicInfo = () => {
 
     useEffect(() => {
         const query = addressQuery.trim();
-        if (query.length < 3 || !GEOAPIFY_API_KEY) {
+        if (query.length < 3 || !isAddressAutocompleteEnabled) {
             setAddressSuggestions([]);
             setAddressLoading(false);
             return;
         }
 
+        let isActive = true;
         const abortController = new AbortController();
         const timeoutId = setTimeout(async () => {
             setAddressLoading(true);
@@ -113,19 +115,25 @@ const CreateTournamentBasicInfo = () => {
                     suggestions.filter((suggestion) => suggestion.label.length > 0)
                 );
             } catch (fetchError: any) {
+                if (!isActive) {
+                    return;
+                }
                 if (fetchError?.name !== "AbortError") {
                     setAddressSuggestions([]);
                 }
             } finally {
-                setAddressLoading(false);
+                if (isActive) {
+                    setAddressLoading(false);
+                }
             }
         }, AUTOCOMPLETE_DEBOUNCE_MS);
 
         return () => {
+            isActive = false;
             clearTimeout(timeoutId);
             abortController.abort();
         };
-    }, [addressQuery]);
+    }, [addressQuery, isAddressAutocompleteEnabled]);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const { name, value } = e.target;
@@ -362,9 +370,9 @@ const CreateTournamentBasicInfo = () => {
                                     ))}
                                 </div>
                             )}
-                            {!GEOAPIFY_API_KEY && (
+                            {!isAddressAutocompleteEnabled && addressQuery.trim().length >= 3 && (
                                 <p className="text-xs text-gray-600">
-                                    Set <code>VITE_GEOAPIFY_API_KEY</code> to enable address suggestions.
+                                    Address suggestions are currently unavailable. You can keep entering your address manually.
                                 </p>
                             )}
                             <input

--- a/frontend/src/pages/CreateTournamentRegistration.tsx
+++ b/frontend/src/pages/CreateTournamentRegistration.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "../styles/LoginPage.css";
 import { API_BASE_URL } from "../config";
+import { parseJsonSafely } from "../utils/http";
+import { formatSqlDateTime } from "../utils/dateTime";
 
 const CreateTournamentRegistration = () => {
     const [formData, setFormData] = useState(() => {
@@ -22,14 +24,6 @@ const CreateTournamentRegistration = () => {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const navigate = useNavigate();
-
-    const parseJsonSafely = async (response: Response) => {
-        try {
-            return await response.json();
-        } catch {
-            return null;
-        }
-    };
 
     const makeApiCall = async (endpoint: string, options: RequestInit = {}) => {
         const url = `${API_BASE_URL}${endpoint}`;
@@ -130,15 +124,6 @@ const CreateTournamentRegistration = () => {
         try {
             const basicInfo = JSON.parse(localStorage.getItem('tournamentBasicInfo') || '{}');
             const format = JSON.parse(localStorage.getItem('tournamentFormat') || '{}');
-            
-            const formatSqlDateTime = (d: Date) => {
-                const pad = (value: number) => String(value).padStart(2, "0");
-                return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(
-                    d.getDate()
-                )} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(
-                    d.getSeconds()
-                )}`;
-            };
 
             const tournamentStartDate = new Date(basicInfo.startDate);
             const tournamentEndDate = new Date(basicInfo.endDate);

--- a/frontend/src/pages/EditTournamentPage.jsx
+++ b/frontend/src/pages/EditTournamentPage.jsx
@@ -1,29 +1,8 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { API_BASE_URL } from "../config";
-
-const toDateInputValue = (dateValue) => {
-    if (!dateValue) {
-        return "";
-    }
-
-    if (typeof dateValue === "string") {
-        const matchedDate = dateValue.match(/^(\d{4}-\d{2}-\d{2})/);
-        if (matchedDate?.[1]) {
-            return matchedDate[1];
-        }
-    }
-
-    const parsedDate = new Date(dateValue);
-    if (Number.isNaN(parsedDate.getTime())) {
-        return "";
-    }
-
-    const localDate = new Date(
-        parsedDate.getTime() - parsedDate.getTimezoneOffset() * 60000
-    );
-    return localDate.toISOString().slice(0, 10);
-};
+import { toDateInputValue } from "../utils/dateTime";
+import { parseJsonSafely } from "../utils/http";
 
 const EditTournamentPage = () => {
     const { id } = useParams();
@@ -123,7 +102,7 @@ const EditTournamentPage = () => {
             });
 
             if (!response.ok) {
-                const errorPayload = await response.json().catch(() => ({}));
+                const errorPayload = await parseJsonSafely(response);
                 throw new Error(
                     errorPayload?.message ||
                         "Unable to update tournament details. Please try again."

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -3,20 +3,13 @@ import { useNavigate, Link } from "react-router-dom";
 import logo from "../assets/rallypoint-logo.png";
 
 import { API_BASE_URL } from "../config";
+import { parseJsonSafely } from "../utils/http";
 
 const LoginPage = () => {
     const [form, setForm] = useState({ email: "", password: "" });
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState(null);
     const navigate = useNavigate();
-
-    const parseJsonSafely = async (response) => {
-        try {
-            return await response.json();
-        } catch {
-            return null;
-        }
-    };
 
     const handleSubmit = async (e) => {
         e.preventDefault();

--- a/frontend/src/pages/RegistrationPage.jsx
+++ b/frontend/src/pages/RegistrationPage.jsx
@@ -47,6 +47,11 @@ const RegistrationPage = () => {
             return;
         }
 
+        if (!GEOAPIFY_API_KEY) {
+            setLocationResults([]);
+            return;
+        }
+
         setLocationLoading(true);
         try {
             const response = await fetch(
@@ -288,6 +293,11 @@ const RegistrationPage = () => {
                                         </li>
                                     ))}
                                 </ul>
+                            )}
+                            {!GEOAPIFY_API_KEY && locationQuery.length >= 3 && (
+                                <div className="absolute left-0 right-0 bg-white text-black p-2 z-10 border border-gray-300 rounded">
+                                    Location suggestions are currently unavailable. Enter location fields manually.
+                                </div>
                             )}
                         </div>
                     </div>

--- a/frontend/src/utils/dateTime.ts
+++ b/frontend/src/utils/dateTime.ts
@@ -1,0 +1,31 @@
+const pad = (value: number) => String(value).padStart(2, "0");
+
+export const formatSqlDateTime = (dateValue: Date): string =>
+  `${dateValue.getFullYear()}-${pad(dateValue.getMonth() + 1)}-${pad(
+    dateValue.getDate()
+  )} ${pad(dateValue.getHours())}:${pad(dateValue.getMinutes())}:${pad(
+    dateValue.getSeconds()
+  )}`;
+
+export const toDateInputValue = (dateValue: unknown): string => {
+  if (!dateValue) {
+    return "";
+  }
+
+  if (typeof dateValue === "string") {
+    const matchedDate = dateValue.match(/^(\d{4}-\d{2}-\d{2})/);
+    if (matchedDate?.[1]) {
+      return matchedDate[1];
+    }
+  }
+
+  const parsedDate = new Date(dateValue as string | number | Date);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return "";
+  }
+
+  const localDate = new Date(
+    parsedDate.getTime() - parsedDate.getTimezoneOffset() * 60000
+  );
+  return localDate.toISOString().slice(0, 10);
+};

--- a/frontend/src/utils/http.ts
+++ b/frontend/src/utils/http.ts
@@ -1,0 +1,9 @@
+export const parseJsonSafely = async <T = unknown>(
+  response: Response
+): Promise<T | null> => {
+  try {
+    return (await response.json()) as T;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
This follow-up PR addresses actionable review comments left on merged PR #61.

### What changed
- Extracted reusable response parsing helper into `frontend/src/utils/http.ts` and reused it in:
  - `frontend/src/pages/LoginPage.jsx`
  - `frontend/src/pages/CreateTournamentRegistration.tsx`
  - `frontend/src/pages/EditTournamentPage.jsx`
- Extracted reusable date helpers into `frontend/src/utils/dateTime.ts` and reused them in:
  - `frontend/src/pages/CreateTournamentRegistration.tsx` (`formatSqlDateTime`)
  - `frontend/src/pages/EditTournamentPage.jsx` (`toDateInputValue`)
- Removed hardcoded Geoapify API key from `frontend/src/config.ts` (now env-only fallback to empty string).
- Updated tournament address autocomplete UX (`CreateTournamentBasicInfo.tsx`):
  - Generic user-facing message when suggestions are unavailable (no env var details exposed)
  - Improved abort handling to avoid stale state updates from canceled requests
- Updated account registration location autocomplete (`RegistrationPage.jsx`) to gracefully skip lookup when no Geoapify key is configured and show a generic manual-entry message.

## Review comment mapping
- Reusable helper extraction: addressed by moving duplicated inline helpers into `frontend/src/utils/http.ts` and `frontend/src/utils/dateTime.ts`.
- Hardcoded API key concern: addressed by removing the default key from `frontend/src/config.ts`.
- User-facing env key text concern: replaced with generic availability text in create/registration flows.
- AbortError handling concern: addressed with guarded cleanup and stale-request protection in tournament address lookup effect.
