### PR TITLE
feat: add tournament match scheduling for directors (#19)

### DIFF
--- a/backend/controllers/tournamentController.js
+++ b/backend/controllers/tournamentController.js
@@ -88,6 +88,28 @@ const unregisterFromTournament = asyncHandler(async (req, res) => {
   res.status(status).json({ message: result.message });
 });
 
+const getTournamentMatchCandidates = asyncHandler(async (req, res) => {
+  const candidates = await tournamentService.getTournamentMatchCandidates(
+    req.params.id
+  );
+  res.status(200).json(candidates);
+});
+
+const getTournamentMatches = asyncHandler(async (req, res) => {
+  const matches = await tournamentService.getTournamentMatches(req.params.id, {
+    date: req.query.date,
+  });
+  res.status(200).json(matches);
+});
+
+const createTournamentMatch = asyncHandler(async (req, res) => {
+  const match = await tournamentService.createTournamentMatch(
+    req.params.id,
+    req.body
+  );
+  res.status(201).json(match);
+});
+
 module.exports = {
   getAllTournaments,
   getTournamentById,
@@ -97,4 +119,7 @@ module.exports = {
   getTournamentTeams,
   registerForTournament,
   unregisterFromTournament,
+  getTournamentMatchCandidates,
+  getTournamentMatches,
+  createTournamentMatch,
 };

--- a/backend/routes/tournamentRoutes.js
+++ b/backend/routes/tournamentRoutes.js
@@ -68,4 +68,28 @@ router.delete(
   asyncHandler(tournamentController.unregisterFromTournament)
 );
 
+router.get(
+  "/:id/matches/candidates",
+  verifyToken,
+  checkTournamentExists,
+  checkTournamentDirector,
+  asyncHandler(tournamentController.getTournamentMatchCandidates)
+);
+
+router.get(
+  "/:id/matches",
+  verifyToken,
+  checkTournamentExists,
+  checkTournamentDirector,
+  asyncHandler(tournamentController.getTournamentMatches)
+);
+
+router.post(
+  "/:id/matches",
+  verifyToken,
+  checkTournamentExists,
+  checkTournamentDirector,
+  asyncHandler(tournamentController.createTournamentMatch)
+);
+
 module.exports = router;

--- a/backend/services/tournamentService.js
+++ b/backend/services/tournamentService.js
@@ -1,5 +1,7 @@
 const knex = require("../knex-config.js");
 const { validateDuplicateRegistration } = require("../utils/validation");
+const { BadRequestError, NotFoundError } = require("../utils/customErrors");
+const { sendEmail } = require("../utils/emailUtils");
 
 const toIsoDateOnly = (dateValue) => {
   const parsedDate = new Date(dateValue);
@@ -240,6 +242,229 @@ const unregisterFromTournament = async (
   }
 };
 
+const getTournamentMatchCandidates = async (tournament_id) =>
+  knex("Registration as r")
+    .join("TournamentDivision as td", "r.tournament_division_id", "td.id")
+    .join("Team as team", "r.team_id", "team.id")
+    .leftJoin("Division as division", "td.division_id", "division.id")
+    .where("td.tournament_id", tournament_id)
+    .where("r.status", "registered")
+    .select(
+      "r.id as registration_id",
+      "r.team_id",
+      "team.name as team_name",
+      "r.tournament_division_id",
+      "division.name as division_name"
+    )
+    .orderBy("team.name", "asc");
+
+const getTournamentMatches = async (tournament_id, filters = {}) => {
+  const query = knex("Series as s")
+    .join("Registration as r1", "s.registration1_id", "r1.id")
+    .join("Registration as r2", "s.registration2_id", "r2.id")
+    .join("Team as t1", "r1.team_id", "t1.id")
+    .join("Team as t2", "r2.team_id", "t2.id")
+    .where("s.tournament_id", tournament_id)
+    .select(
+      "s.id",
+      "s.tournament_id",
+      "s.registration1_id",
+      "s.registration2_id",
+      "s.winner_id",
+      "s.wins_needed",
+      "s.location",
+      "s.created_at as scheduled_at",
+      "t1.id as team1_id",
+      "t1.name as team1_name",
+      "t2.id as team2_id",
+      "t2.name as team2_name"
+    )
+    .orderBy("s.created_at", "asc");
+
+  if (filters.date) {
+    query.whereRaw("DATE(s.created_at) = ?", [filters.date]);
+  }
+
+  return query;
+};
+
+const getTournamentMatchById = async (tournament_id, matchId) => {
+  const matches = await getTournamentMatches(tournament_id);
+  return matches.find((match) => match.id === matchId) || null;
+};
+
+const validateMatchScheduleInput = (matchData = {}) => {
+  const {
+    registration1_id,
+    registration2_id,
+    scheduled_date,
+    scheduled_time,
+    location,
+  } = matchData;
+
+  if (
+    !registration1_id ||
+    !registration2_id ||
+    !scheduled_date ||
+    !scheduled_time ||
+    !location
+  ) {
+    throw new BadRequestError(
+      "registration1_id, registration2_id, scheduled_date, scheduled_time, and location are required"
+    );
+  }
+
+  const registration1IdNumber = Number(registration1_id);
+  const registration2IdNumber = Number(registration2_id);
+  if (
+    !Number.isInteger(registration1IdNumber) ||
+    !Number.isInteger(registration2IdNumber)
+  ) {
+    throw new BadRequestError("registration ids must be integers");
+  }
+
+  if (registration1IdNumber === registration2IdNumber) {
+    throw new BadRequestError(
+      "registration1_id and registration2_id must be different teams"
+    );
+  }
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(scheduled_date)) {
+    throw new BadRequestError("scheduled_date must be in YYYY-MM-DD format");
+  }
+
+  if (!/^\d{2}:\d{2}$/.test(scheduled_time)) {
+    throw new BadRequestError("scheduled_time must be in HH:mm format");
+  }
+
+  const scheduledDateTime = new Date(`${scheduled_date}T${scheduled_time}:00`);
+  if (Number.isNaN(scheduledDateTime.getTime())) {
+    throw new BadRequestError("Invalid scheduled date/time");
+  }
+
+  const winsNeeded =
+    matchData.wins_needed === undefined || matchData.wins_needed === null
+      ? 1
+      : Number(matchData.wins_needed);
+
+  if (!Number.isInteger(winsNeeded) || winsNeeded <= 0) {
+    throw new BadRequestError("wins_needed must be a positive integer");
+  }
+
+  return {
+    registration1IdNumber,
+    registration2IdNumber,
+    winsNeeded,
+    scheduledAtSql: `${scheduled_date} ${scheduled_time}:00`,
+    location: `${location}`.trim(),
+  };
+};
+
+const getTeamNotificationEmails = async (teamIds) => {
+  const rows = await knex("UserTeam as ut")
+    .join("User as u", "ut.user_id", "u.id")
+    .whereIn("ut.team_id", teamIds)
+    .where("ut.status", "accepted")
+    .whereNotNull("u.email")
+    .distinct("u.email");
+
+  return rows.map((row) => row.email).filter(Boolean);
+};
+
+const sendMatchScheduleNotifications = async (scheduledMatch) => {
+  if (
+    process.env.NODE_ENV === "test" ||
+    process.env.MATCH_SCHEDULE_EMAILS === "false"
+  ) {
+    return { attempted: false, delivered: 0, failed: 0, recipients: [] };
+  }
+
+  const recipients = await getTeamNotificationEmails([
+    scheduledMatch.team1_id,
+    scheduledMatch.team2_id,
+  ]);
+
+  if (!recipients.length) {
+    return { attempted: false, delivered: 0, failed: 0, recipients: [] };
+  }
+
+  const scheduledDisplay = new Date(scheduledMatch.scheduled_at).toLocaleString();
+  const subject = `Match Scheduled: ${scheduledMatch.team1_name} vs ${scheduledMatch.team2_name}`;
+  const html = `
+    <p>A new match has been scheduled.</p>
+    <p><strong>Teams:</strong> ${scheduledMatch.team1_name} vs ${scheduledMatch.team2_name}</p>
+    <p><strong>When:</strong> ${scheduledDisplay}</p>
+    <p><strong>Location:</strong> ${scheduledMatch.location}</p>
+  `;
+
+  const settled = await Promise.allSettled(
+    recipients.map((email) => sendEmail(email, subject, html))
+  );
+
+  const delivered = settled.filter((result) => result.status === "fulfilled").length;
+  const failed = settled.length - delivered;
+
+  return {
+    attempted: true,
+    delivered,
+    failed,
+    recipients,
+  };
+};
+
+const createTournamentMatch = async (tournament_id, matchData) => {
+  const {
+    registration1IdNumber,
+    registration2IdNumber,
+    winsNeeded,
+    scheduledAtSql,
+    location,
+  } = validateMatchScheduleInput(matchData);
+
+  if (!location) {
+    throw new BadRequestError("location is required");
+  }
+
+  const registrations = await knex("Registration as r")
+    .join("TournamentDivision as td", "r.tournament_division_id", "td.id")
+    .whereIn("r.id", [registration1IdNumber, registration2IdNumber])
+    .where("td.tournament_id", tournament_id)
+    .where("r.status", "registered")
+    .select("r.id", "r.team_id");
+
+  if (registrations.length !== 2) {
+    throw new NotFoundError(
+      "One or both registrations are not active for this tournament"
+    );
+  }
+
+  const [registrationOne, registrationTwo] = registrations;
+  if (registrationOne.team_id === registrationTwo.team_id) {
+    throw new BadRequestError("A team cannot be scheduled to play itself");
+  }
+
+  const [seriesId] = await knex("Series").insert({
+    tournament_id,
+    registration1_id: registration1IdNumber,
+    registration2_id: registration2IdNumber,
+    wins_needed: winsNeeded,
+    location,
+    created_at: scheduledAtSql,
+  });
+
+  const createdMatch = await getTournamentMatchById(tournament_id, seriesId);
+  if (!createdMatch) {
+    throw new NotFoundError("Scheduled match could not be retrieved");
+  }
+
+  const notifications = await sendMatchScheduleNotifications(createdMatch);
+
+  return {
+    ...createdMatch,
+    notifications,
+  };
+};
+
 module.exports = {
   getAllTournaments,
   getTournamentById,
@@ -249,4 +474,7 @@ module.exports = {
   getTournamentTeams,
   registerForTournament,
   unregisterFromTournament,
+  getTournamentMatchCandidates,
+  getTournamentMatches,
+  createTournamentMatch,
 };

--- a/backend/tests/tournamentController.test.js
+++ b/backend/tests/tournamentController.test.js
@@ -96,6 +96,74 @@ describe("Tournament Controller API Tests", () => {
     }
   });
 
+  const createScheduleFixture = async () => {
+    const uniqueSuffix = `${Date.now()}${Math.floor(Math.random() * 10000)}`;
+
+    const [teamOneId] = await knex("Team").insert({
+      name: `Schedule Team One ${uniqueSuffix}`,
+      public: true,
+      description: "Team used for scheduling tests",
+      created_at: new Date(),
+    });
+
+    const [teamTwoId] = await knex("Team").insert({
+      name: `Schedule Team Two ${uniqueSuffix}`,
+      public: true,
+      description: "Team used for scheduling tests",
+      created_at: new Date(),
+    });
+
+    await knex("UserTeam").insert([
+      {
+        user_id: testUserObject.id,
+        team_id: teamOneId,
+        role: "player",
+        status: "accepted",
+        created_at: new Date(),
+      },
+      {
+        user_id: testUserObject.id,
+        team_id: teamTwoId,
+        role: "player",
+        status: "accepted",
+        created_at: new Date(),
+      },
+    ]);
+
+    const [registrationOneId] = await knex("Registration").insert({
+      team_id: teamOneId,
+      tournament_division_id: tournamentDivisionId,
+      status: "registered",
+      payment_status: "unpaid",
+      created_at: new Date(),
+    });
+
+    const [registrationTwoId] = await knex("Registration").insert({
+      team_id: teamTwoId,
+      tournament_division_id: tournamentDivisionId,
+      status: "registered",
+      payment_status: "unpaid",
+      created_at: new Date(),
+    });
+
+    return {
+      teamOneId,
+      teamTwoId,
+      registrationOneId,
+      registrationTwoId,
+    };
+  };
+
+  const cleanupScheduleFixture = async (fixture) => {
+    if (!fixture) {
+      return;
+    }
+
+    await knex("Team")
+      .whereIn("id", [fixture.teamOneId, fixture.teamTwoId])
+      .del();
+  };
+
   afterAll(async () => {
     // Clean up the database after tests
     try {
@@ -638,6 +706,89 @@ describe("Tournament Controller API Tests", () => {
     expect(duplicateRes.body.message).toBe(
       "Team is already registered for this tournament division"
     );
+  });
+
+  test("GET /api/tournaments/:id/matches/candidates should return registration candidates", async () => {
+    const fixture = await createScheduleFixture();
+    try {
+      const response = await request(app)
+        .get(`/api/tournaments/${testTournamentId}/matches/candidates`)
+        .set("Authorization", `Bearer ${testUserObject.token}`);
+
+      expect(response.statusCode).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(
+        response.body.some(
+          (candidate) => candidate.registration_id === fixture.registrationOneId
+        )
+      ).toBe(true);
+      expect(
+        response.body.some(
+          (candidate) => candidate.registration_id === fixture.registrationTwoId
+        )
+      ).toBe(true);
+    } finally {
+      await cleanupScheduleFixture(fixture);
+    }
+  });
+
+  test("POST /api/tournaments/:id/matches should create a scheduled match", async () => {
+    const fixture = await createScheduleFixture();
+    try {
+      const scheduleResponse = await request(app)
+        .post(`/api/tournaments/${testTournamentId}/matches`)
+        .set("Authorization", `Bearer ${testUserObject.token}`)
+        .send({
+          registration1_id: fixture.registrationOneId,
+          registration2_id: fixture.registrationTwoId,
+          scheduled_date: dateWithOffset(2),
+          scheduled_time: "14:30",
+          location: "Court 1",
+        });
+
+      expect(scheduleResponse.statusCode).toBe(201);
+      expect(scheduleResponse.body).toHaveProperty("id");
+      expect(scheduleResponse.body.registration1_id).toBe(
+        fixture.registrationOneId
+      );
+      expect(scheduleResponse.body.registration2_id).toBe(
+        fixture.registrationTwoId
+      );
+      expect(scheduleResponse.body.location).toBe("Court 1");
+
+      const listResponse = await request(app)
+        .get(`/api/tournaments/${testTournamentId}/matches`)
+        .set("Authorization", `Bearer ${testUserObject.token}`);
+
+      expect(listResponse.statusCode).toBe(200);
+      expect(Array.isArray(listResponse.body)).toBe(true);
+      expect(
+        listResponse.body.some((match) => match.id === scheduleResponse.body.id)
+      ).toBe(true);
+    } finally {
+      await cleanupScheduleFixture(fixture);
+    }
+  });
+
+  test("POST /api/tournaments/:id/matches should reject identical registrations", async () => {
+    const fixture = await createScheduleFixture();
+    try {
+      const response = await request(app)
+        .post(`/api/tournaments/${testTournamentId}/matches`)
+        .set("Authorization", `Bearer ${testUserObject.token}`)
+        .send({
+          registration1_id: fixture.registrationOneId,
+          registration2_id: fixture.registrationOneId,
+          scheduled_date: dateWithOffset(2),
+          scheduled_time: "10:00",
+          location: "Court 2",
+        });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.body.message).toContain("must be different teams");
+    } finally {
+      await cleanupScheduleFixture(fixture);
+    }
   });
 
   test("GET /api/tournaments/:id/teams should return 404 for a non-existent tournament", async () => {

--- a/frontend/src/pages/TournamentManagementPage.jsx
+++ b/frontend/src/pages/TournamentManagementPage.jsx
@@ -141,6 +141,13 @@ const TournamentManagementPage = () => {
                             </button>
                             <button
                                 type="button"
+                                onClick={() => navigate(`/events/${id}/schedule`)}
+                                className="px-4 py-2 rounded-md bg-indigo-700 text-white hover:bg-indigo-600 transition-colors"
+                            >
+                                Schedule Matches
+                            </button>
+                            <button
+                                type="button"
                                 onClick={handleDeleteTournament}
                                 disabled={deleting}
                                 className="px-4 py-2 rounded-md bg-red-600 text-white hover:bg-red-700 transition-colors disabled:bg-gray-400"

--- a/frontend/src/pages/TournamentSchedulePage.jsx
+++ b/frontend/src/pages/TournamentSchedulePage.jsx
@@ -1,0 +1,354 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { API_BASE_URL } from "../config";
+import { formatSqlDateTime } from "../utils/dateTime";
+import { parseJsonSafely } from "../utils/http";
+
+const formatDateTime = (dateValue) => {
+    if (!dateValue) {
+        return "TBD";
+    }
+
+    const parsedDate = new Date(dateValue);
+    if (Number.isNaN(parsedDate.getTime())) {
+        return "TBD";
+    }
+
+    return parsedDate.toLocaleString();
+};
+
+const TournamentSchedulePage = () => {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [candidates, setCandidates] = useState([]);
+    const [matches, setMatches] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState("");
+    const [message, setMessage] = useState("");
+    const [formData, setFormData] = useState({
+        registration1_id: "",
+        registration2_id: "",
+        scheduled_date: "",
+        scheduled_time: "",
+        location: "",
+    });
+
+    const getTokenOrRedirect = () => {
+        const token = localStorage.getItem("authToken");
+        if (!token) {
+            setError("Please log in to manage match schedules.");
+            navigate("/login", {
+                replace: true,
+                state: { from: `/events/${id}/schedule` },
+            });
+            return null;
+        }
+        return token;
+    };
+
+    const loadPageData = async () => {
+        const token = getTokenOrRedirect();
+        if (!token) {
+            return;
+        }
+
+        try {
+            setLoading(true);
+            setError("");
+            const [candidatesResponse, matchesResponse] = await Promise.all([
+                fetch(`${API_BASE_URL}/api/tournaments/${id}/matches/candidates`, {
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                    },
+                }),
+                fetch(`${API_BASE_URL}/api/tournaments/${id}/matches`, {
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                    },
+                }),
+            ]);
+
+            if (!candidatesResponse.ok) {
+                const payload = await parseJsonSafely(candidatesResponse);
+                throw new Error(
+                    payload?.message || "Unable to load eligible teams for scheduling."
+                );
+            }
+
+            if (!matchesResponse.ok) {
+                const payload = await parseJsonSafely(matchesResponse);
+                throw new Error(
+                    payload?.message || "Unable to load current match schedule."
+                );
+            }
+
+            const candidatesData = (await parseJsonSafely(candidatesResponse)) || [];
+            const matchesData = (await parseJsonSafely(matchesResponse)) || [];
+            setCandidates(Array.isArray(candidatesData) ? candidatesData : []);
+            setMatches(Array.isArray(matchesData) ? matchesData : []);
+        } catch (loadError) {
+            setError(loadError?.message || "Unable to load match scheduling data.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        loadPageData();
+    }, [id]);
+
+    const handleChange = (event) => {
+        const { name, value } = event.target;
+        setFormData((previous) => ({
+            ...previous,
+            [name]: value,
+        }));
+    };
+
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        setError("");
+        setMessage("");
+
+        const token = getTokenOrRedirect();
+        if (!token) {
+            return;
+        }
+
+        if (
+            !formData.registration1_id ||
+            !formData.registration2_id ||
+            !formData.scheduled_date ||
+            !formData.scheduled_time ||
+            !formData.location
+        ) {
+            setError("Please complete all schedule fields before submitting.");
+            return;
+        }
+
+        if (formData.registration1_id === formData.registration2_id) {
+            setError("Team 1 and Team 2 must be different teams.");
+            return;
+        }
+
+        const scheduledDateTime = new Date(
+            `${formData.scheduled_date}T${formData.scheduled_time}:00`
+        );
+        if (Number.isNaN(scheduledDateTime.getTime())) {
+            setError("Please provide a valid scheduled date and time.");
+            return;
+        }
+
+        try {
+            setSubmitting(true);
+            const response = await fetch(`${API_BASE_URL}/api/tournaments/${id}/matches`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${token}`,
+                },
+                body: JSON.stringify({
+                    registration1_id: Number(formData.registration1_id),
+                    registration2_id: Number(formData.registration2_id),
+                    scheduled_date: formData.scheduled_date,
+                    scheduled_time: formData.scheduled_time,
+                    location: formData.location.trim(),
+                    scheduled_at: formatSqlDateTime(scheduledDateTime),
+                }),
+            });
+
+            if (!response.ok) {
+                const payload = await parseJsonSafely(response);
+                throw new Error(
+                    payload?.message || "Unable to schedule the match. Please try again."
+                );
+            }
+
+            const createdMatch = await parseJsonSafely(response);
+            const deliveredCount = createdMatch?.notifications?.delivered || 0;
+            setMessage(
+                `Match scheduled successfully.${deliveredCount > 0 ? ` Notifications sent: ${deliveredCount}.` : ""}`
+            );
+            setFormData((previous) => ({
+                ...previous,
+                registration1_id: "",
+                registration2_id: "",
+                scheduled_date: "",
+                scheduled_time: "",
+                location: "",
+            }));
+            await loadPageData();
+        } catch (submitError) {
+            setError(submitError?.message || "Unable to schedule the match.");
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="min-h-[90vh] w-full flex items-center justify-center text-black px-4">
+            <div className="w-full max-w-4xl bg-white rounded-lg border border-gray-200 p-6 sm:p-8 shadow-sm">
+                <h1 className="text-2xl sm:text-3xl font-bold text-blue-900 mb-4">
+                    Schedule Matches
+                </h1>
+
+                {loading ? <p>Loading schedule data...</p> : null}
+                {error ? <p className="text-red-600 mb-4">{error}</p> : null}
+                {message ? <p className="text-green-700 mb-4 font-semibold">{message}</p> : null}
+
+                {!loading ? (
+                    <>
+                        <form onSubmit={handleSubmit} className="space-y-4">
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                <div>
+                                    <label htmlFor="registration1_id" className="font-semibold block mb-1">
+                                        Team 1
+                                    </label>
+                                    <select
+                                        id="registration1_id"
+                                        name="registration1_id"
+                                        value={formData.registration1_id}
+                                        onChange={handleChange}
+                                        className="w-full border border-gray-300 rounded-md p-2"
+                                        required
+                                    >
+                                        <option value="">Select first team</option>
+                                        {candidates.map((candidate) => (
+                                            <option
+                                                key={`team1-${candidate.registration_id}`}
+                                                value={candidate.registration_id}
+                                            >
+                                                {candidate.team_name} (Registration #{candidate.registration_id})
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+
+                                <div>
+                                    <label htmlFor="registration2_id" className="font-semibold block mb-1">
+                                        Team 2
+                                    </label>
+                                    <select
+                                        id="registration2_id"
+                                        name="registration2_id"
+                                        value={formData.registration2_id}
+                                        onChange={handleChange}
+                                        className="w-full border border-gray-300 rounded-md p-2"
+                                        required
+                                    >
+                                        <option value="">Select second team</option>
+                                        {candidates.map((candidate) => (
+                                            <option
+                                                key={`team2-${candidate.registration_id}`}
+                                                value={candidate.registration_id}
+                                            >
+                                                {candidate.team_name} (Registration #{candidate.registration_id})
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                                <div>
+                                    <label htmlFor="scheduled_date" className="font-semibold block mb-1">
+                                        Match Date
+                                    </label>
+                                    <input
+                                        type="date"
+                                        id="scheduled_date"
+                                        name="scheduled_date"
+                                        value={formData.scheduled_date}
+                                        onChange={handleChange}
+                                        className="w-full border border-gray-300 rounded-md p-2"
+                                        required
+                                    />
+                                </div>
+                                <div>
+                                    <label htmlFor="scheduled_time" className="font-semibold block mb-1">
+                                        Match Time
+                                    </label>
+                                    <input
+                                        type="time"
+                                        id="scheduled_time"
+                                        name="scheduled_time"
+                                        value={formData.scheduled_time}
+                                        onChange={handleChange}
+                                        className="w-full border border-gray-300 rounded-md p-2"
+                                        required
+                                    />
+                                </div>
+                                <div>
+                                    <label htmlFor="location" className="font-semibold block mb-1">
+                                        Match Location
+                                    </label>
+                                    <input
+                                        id="location"
+                                        name="location"
+                                        value={formData.location}
+                                        onChange={handleChange}
+                                        className="w-full border border-gray-300 rounded-md p-2"
+                                        placeholder="Court / Field / Venue"
+                                        required
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="flex flex-wrap gap-3">
+                                <button
+                                    type="submit"
+                                    disabled={submitting}
+                                    className="px-4 py-2 rounded-md bg-blue-900 text-white hover:bg-blue-800 transition-colors disabled:bg-gray-400"
+                                >
+                                    {submitting ? "Scheduling..." : "Schedule Match"}
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => navigate(`/events/${id}/manage`)}
+                                    className="px-4 py-2 rounded-md bg-gray-100 text-gray-800 border border-gray-300 hover:bg-gray-200 transition-colors"
+                                >
+                                    Back to Management
+                                </button>
+                            </div>
+                        </form>
+
+                        <div className="mt-8">
+                            <h2 className="text-xl font-semibold text-blue-900 mb-3">
+                                Current Match Schedule
+                            </h2>
+                            {matches.length === 0 ? (
+                                <p className="text-gray-700">No matches have been scheduled yet.</p>
+                            ) : (
+                                <div className="overflow-x-auto border border-gray-200 rounded-md">
+                                    <table className="min-w-full text-sm">
+                                        <thead className="bg-gray-50">
+                                            <tr>
+                                                <th className="text-left p-3 font-semibold">Teams</th>
+                                                <th className="text-left p-3 font-semibold">Date & Time</th>
+                                                <th className="text-left p-3 font-semibold">Location</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {matches.map((match) => (
+                                                <tr key={match.id} className="border-t border-gray-200">
+                                                    <td className="p-3">
+                                                        {match.team1_name} vs {match.team2_name}
+                                                    </td>
+                                                    <td className="p-3">{formatDateTime(match.scheduled_at)}</td>
+                                                    <td className="p-3">{match.location || "TBD"}</td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            )}
+                        </div>
+                    </>
+                ) : null}
+            </div>
+        </div>
+    );
+};
+
+export default TournamentSchedulePage;

--- a/frontend/src/routes/AppRoutes.jsx
+++ b/frontend/src/routes/AppRoutes.jsx
@@ -10,6 +10,7 @@ import CreateTournamentFormat from "../pages/CreateTournamentFormat";
 import CreateTournamentRegistration from "../pages/CreateTournamentRegistration";
 import TournamentManagementPage from "../pages/TournamentManagementPage";
 import EditTournamentPage from "../pages/EditTournamentPage";
+import TournamentSchedulePage from "../pages/TournamentSchedulePage";
 import TournamentEventPage from "../pages/TournamentEventPage";
 // import RankingsPage from '../pages/RankingsPage';
 import NotFoundPage from "../pages/NotFoundPage";
@@ -31,6 +32,7 @@ const AppRoutes = () => {
                 <Route path="/events/:id" element={<TournamentEventPage />} />
                 <Route path="/events/:id/manage" element={<TournamentManagementPage />} />
                 <Route path="/events/:id/edit" element={<EditTournamentPage />} />
+                <Route path="/events/:id/schedule" element={<TournamentSchedulePage />} />
                 <Route path="/about" element={<AboutPage />} />
                 <Route path="/profile" element={<ProfilePage />} />
             </Route>


### PR DESCRIPTION
## Summary
Implements issue #19 by adding a full tournament match scheduling workflow for tournament directors.

## What Changed
- Added protected tournament scheduling APIs:
  - `GET /api/tournaments/:id/matches/candidates`
  - `GET /api/tournaments/:id/matches`
  - `POST /api/tournaments/:id/matches`
- Added backend validation for scheduling input:
  - requires two different registrations
  - requires valid `YYYY-MM-DD` date and `HH:mm` time
  - requires non-empty location
  - requires active registrations in the same tournament
- Added schedule persistence using `Series` table with schedule timestamp and location.
- Added team notification dispatch after successful scheduling (email utility), with test-safe behavior.
- Added new frontend page at `/events/:id/schedule` with:
  - team selectors from eligible registrations
  - date/time/location form
  - schedule list display
  - success/error feedback
- Added “Schedule Matches” action button to tournament management page.
- Added backend integration tests for:
  - candidates retrieval
  - successful schedule creation
  - invalid identical-team scheduling rejection

## Verification Run
- `backend`: `JWT_SECRET=test-secret-for-local-ci npx jest tests/tournamentController.test.js --runInBand --testTimeout=30000 --config '{"testEnvironment":"node"}'`
- `frontend`: `npm run build`

## Reviewer Validation Steps
1. Log in as a tournament director user.
2. Open `/events/:id/manage` and click **Schedule Matches**.
3. Create a match with two valid teams, date, time, and location.
4. Confirm success message and the new match appears in the schedule table.
5. Try selecting the same team for both sides and confirm a validation error.
6. Call `GET /api/tournaments/:id/matches` and confirm returned schedule data matches UI.

Closes #19

AI Disclosure: Drafted with AI assistance.
Validated By: codex
Validation Date: 2026-02-26
